### PR TITLE
Add CI workflow for PR linting checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  markdown-lint:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "**/*.md"
+
+  shell-lint:
+    name: Shell lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: .
+          severity: warning
+
+  dockerfile-lint:
+    name: Dockerfile lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/Dockerfile

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,7 @@
+config:
+  # Allow long lines — tables and URLs often exceed 80 chars
+  MD013: false
+  # Allow duplicate headings in different files (templates reuse headings)
+  MD024: false
+  # Allow inline HTML (used in some prompts/templates)
+  MD033: false


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow that runs on PRs to `main`
- Three parallel lint jobs: markdownlint (`.md`), shellcheck (`.sh`), hadolint (`Dockerfile`)
- Add `.markdownlint-cli2.yaml` config to suppress noisy rules (long lines, duplicate headings, inline HTML)

## Test plan
- [ ] Verify CI jobs trigger on this PR
- [ ] Review lint results — fix any legitimate issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)