### PR TITLE
Fix Docker git email and add prompt guardrails

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,7 @@ RUN touch /var/log/git-commands.log && \
     chown node:node /var/log/git-commands.log
 
 # Git configuration (use real binary directly — wrapper is already in PATH)
-RUN /usr/bin/git config --system user.email "ralph@example.com" && \
+RUN /usr/bin/git config --system user.email "ralph-loop[bot]@users.noreply.github.com" && \
     /usr/bin/git config --system user.name "Ralph Loop"
 
 # Workspace and config directories

--- a/templates/prompt.md
+++ b/templates/prompt.md
@@ -91,3 +91,6 @@ f. If you hit a problem that wasted time, add a guardrail to docs/guardrails.md
 - Never skip failing tests
 - Commit after each completed task
 - If stuck after genuine effort, document what you tried and move on
+- Do NOT modify verify.sh unless the task explicitly requires it
+- Do NOT use hardcoded container paths (e.g. `/workspace`) — code must work both inside Docker and on the host machine
+- Do NOT set PYTHONPATH to fix import issues — use `pip install -e .` instead


### PR DESCRIPTION
## Summary
- Changed Docker git email from `ralph@example.com` to `ralph-loop[bot]@users.noreply.github.com` to avoid GitHub email privacy push rejections (hit this on ergofigure PR #25)
- Added three guardrails to prompt template:
  - Don't modify verify.sh unless explicitly required
  - Don't use hardcoded container paths (`/workspace`)
  - Don't set PYTHONPATH — use `pip install -e .` instead

## Test plan
- [ ] Rebuild Docker image and verify git config: `docker run --rm ralph-claude:latest -c "git config user.email"`
- [ ] Review prompt template rules make sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)