### PR TITLE
Add plan review and bead generation templates

### DIFF
--- a/templates/generate-beads.md
+++ b/templates/generate-beads.md
@@ -38,7 +38,7 @@ If you need "and", split into two beads.
 
 ### 2. Single Architectural Layer
 
-Each bead touches ONE layer: backend OR frontend OR infrastructure. Never both.
+Each bead touches ONE layer: backend OR frontend OR infrastructure OR integration. Never both.
 
 - GOOD: "Add distance calculation endpoint (backend)"
 - BAD: "Add distance calculation and display results in GUI"

--- a/templates/review-plan.md
+++ b/templates/review-plan.md
@@ -179,5 +179,4 @@ For highest quality, paste the plan into a separate LLM conversation (different 
 
 Prompt for the reviewing LLM:
 > "Review this plan/specification for an autonomous AI coding agent. Focus on: completeness, architectural clarity, acceptance criteria quality (must be machine-testable), decomposability into small single-layer tasks, dependency ordering, and risk coverage. Be specific — suggest exact changes, not general advice."
-
 > **Source**: Jeffrey Emanuel's iterative review process — 4-5 rounds until suggestions become incremental is the empirical sweet spot.


### PR DESCRIPTION
## Summary
- **review-plan.md**: 6-pass plan review for agent-readiness (completeness, architecture, acceptance criteria quality, decomposability, dependencies, risks)
- **generate-beads.md**: Structured bead generation with decomposition rules, EARS-format acceptance criteria, dependency DAG ordering, and post-generation self-review

Addresses the c00 incident where beads were too large, crossed architectural boundaries, and had vague acceptance criteria.

## Sources synthesized
Anthropic harness patterns, Huntley guardrails, EARS syntax (Kiro), Augment Code multi-file research, Emanuel iterative review, Chroma context rot research, Yegge Rule of Five, Spec Kit constitution.md.

## Test plan
- [ ] Both templates render as valid Markdown
- [ ] Templates are self-contained (usable without external references)
- [ ] Each template references sources for key guidance

Generated with [Claude Code](https://claude.com/claude-code)