### PR TITLE
feat: stream Docker output to log in real-time

### DIFF
--- a/scripts/ralph-afk.sh
+++ b/scripts/ralph-afk.sh
@@ -233,6 +233,7 @@ for ((i=1; i<=MAX_ITERATIONS; i++)); do
         2>&1 | tee -a "$LOG_FILE" > "$ITER_LOG" || true
 
     RESULT=$(cat "$ITER_LOG")
+    rm -f "$ITER_LOG"
 
     # Check for completion signal
     if echo "$RESULT" | grep -q "<promise>COMPLETE</promise>"; then


### PR DESCRIPTION
## Summary
- Replace buffered `RESULT=$(docker run ...)` with `tee`-based streaming so `tail -f` on the log file shows live Claude output during iterations
- Add `git diff --stat` and last commit info between iterations for at-a-glance progress monitoring
- Addresses visibility gap where logs showed nothing between iteration start/end

## Test plan
- [ ] Run a short AFK session (2-3 iterations) and verify `tail -f` shows real-time output
- [ ] Verify signal detection (COMPLETE/BLOCKED/verify-fail) still works correctly
- [ ] Verify git diff --stat appears between iterations

Generated with [Claude Code](https://claude.com/claude-code)