### PR TITLE
docs: cross-platform beads sync guidance

### DIFF
--- a/docs/running-ralph.md
+++ b/docs/running-ralph.md
@@ -509,15 +509,17 @@ Omarchy's SQLite contains old beads from previous naming eras (`ergofigure-eye-d
 
 ```bash
 # On Omarchy — sync and then filter to current prefix only
-docker run --rm -v "$(pwd):/workspace" -w /workspace ralph-claude:latest -c "bd sync"
+docker run --rm -v "$(pwd):/workspace" -w /workspace ralph-claude:latest -c "bd sync" && \
 python3 -c "
-import json
-with open('.beads/issues.jsonl') as f:
+import json, os; inf = '.beads/issues.jsonl'
+
+with open(inf) as f:
     beads = [json.loads(l) for l in f if l.strip()]
 current = [b for b in beads if b['id'].startswith('ergo-')]
-with open('.beads/issues.jsonl', 'w') as f:
+with open(inf + '.tmp', 'w') as f:
     for b in current:
         f.write(json.dumps(b, separators=(',', ':')) + '\n')
+os.replace(inf + '.tmp', inf)
 print(f'Kept {len(current)} ergo-* beads, removed {len(beads) - len(current)} legacy')
 "
 ```


### PR DESCRIPTION
## Summary
- Document the JSONL sync problem: `bd close` writes to local database only, not JSONL
- Add safe sync approach for Omarchy (filter legacy duplicates after `bd sync`)
- Add quick status check commands
- Document merge ordering for multi-machine JSONL changes
- Add sync step (#6) to post-AFK checklist

## Context
Incident 2026-02-21: Omarchy Ralph closed 14 beads but closures stayed in SQLite.
Naive `bd sync` exported 124 legacy beads (from old naming prefixes) into JSONL.

## Test plan
- [x] Docs render correctly
- [x] Commands verified against actual workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)