### PR TITLE
docs: use S/P variables for Windows AFK launch commands

### DIFF
--- a/docs/running-ralph.md
+++ b/docs/running-ralph.md
@@ -200,7 +200,9 @@ bash "$S" "$P" 1 ralph-with-beads/prompts/diagnostic-test.md --label all
 **MCP GUI test** (confirms windows-mcp Snapshot/Click tools work inside Ralph):
 ```bash
 cd "$HOME/OneDrive/10 Business/IT Skills"
-bash ralph-with-beads/scripts/ralph-afk-windows.sh ergofigure-eye-demonstration 1 ralph-with-beads/prompts/diagnostic-mcp.md --label all
+S=ralph-with-beads/scripts/ralph-afk-windows.sh
+P=ergofigure-eye-demonstration
+bash "$S" "$P" 1 ralph-with-beads/prompts/diagnostic-mcp.md --label all
 ```
 
 Expected outcome:


### PR DESCRIPTION
## Summary
- Use `S` and `P` shell variables in Windows AFK examples for shorter, pasteable commands
- Avoids Git Bash line-break issues with long commands containing spaces
- Updated both AFK and diagnostic test examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)