### PR TITLE
Document Dolt database recovery procedure

### DIFF
--- a/docs/running-ralph.md
+++ b/docs/running-ralph.md
@@ -491,7 +491,7 @@ After a PR merge that removes `.beads/dolt/` from git tracking (or after any sit
 
 ```bash
 # 1. Back up the JSONL (source of truth)
-cp .beads/issues.jsonl /tmp/issues.jsonl.bak
+cp .beads/issues.jsonl ~/issues.jsonl.bak
 
 # 2. Remove corrupt/stale Dolt state
 #    Keep: issues.jsonl, .gitignore, config.yaml, hooks/, README.md


### PR DESCRIPTION
## Summary
- Add recovery steps for reinitializing Dolt database from JSONL after it's lost/corrupted
- Documents the key finding: `bd init --from-jsonl` creates an empty DB, explicit `bd import -i` is needed to hydrate
- Covers symptoms, step-by-step recovery, and when this situation occurs

## Context
Discovered during git-cleanup after merging PR #74 (ergofigure), which removed `.beads/dolt/` from git tracking. The merge left a corrupt local Dolt state that needed manual recovery.

## Test plan
- [ ] Markdown lint passes
- [ ] Steps are accurate (verified working 2026-02-23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)