### PR TITLE
fix: improve Ralph operational reliability (#43, #46)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN npm install -g @beads/bd playwright
 USER root
 RUN npx playwright install --with-deps chromium && \
     pip3 install --no-cache-dir --break-system-packages \
-        pytest==8.* pytest-cov==6.* ruff==0.9.* black==25.* mypy==1.15.*
+        pytest==8.* pytest-cov==6.* pytest-timeout==2.* ruff==0.9.* black==25.* mypy==1.15.*
 
 # --- Security: Git wrapper intercepts all git commands via PATH precedence ---
 # /usr/local/bin precedes /usr/bin in PATH, so this wrapper intercepts all git calls.

--- a/prompts/loop-mcp.md
+++ b/prompts/loop-mcp.md
@@ -27,12 +27,13 @@ Priority order:
    - If ALL beads are closed → output `<promise>COMPLETE</promise>` and STOP
    - If some beads are open but ALL are blocked → output `<promise>BLOCKED</promise>` with explanation of what's blocking, and STOP
 
-## STEP 2: UNDERSTAND THE TASK
+## STEP 2: UNDERSTAND AND CLAIM THE TASK
 
-1. Read the bead description carefully
-2. Identify acceptance criteria
-3. Check dependencies and related beads
-4. If the bead is `in_progress` (resumed from previous iteration), check git log and existing code to understand what was already done
+1. Claim the bead: `bd update <id> in_progress` (skip if already `in_progress`)
+2. Read the bead description carefully — identify every acceptance criterion
+3. Read the key files listed in the bead description
+4. Check dependencies and related beads
+5. If the bead is `in_progress` (resumed from previous iteration), check git log and existing code to understand what was already done — do NOT redo completed work
 
 ## STEP 3: IMPLEMENT WITH TDD
 
@@ -153,11 +154,16 @@ If you are running low on context:
 
 ## STEP 7: COMPLETE THE TASK
 
-1. Close the bead: `bd close <id> --reason "what was done"`
+**CRITICAL — `bd close` is MANDATORY. Do NOT skip it.** Without `bd close`, the bead stays open and will be re-assigned in the next iteration, wasting work.
+
+1. Close the bead FIRST: `bd close <id> --reason "criterion-by-criterion close reason"`
+   - The close reason MUST reference each acceptance criterion and how it was satisfied
+   - Verify `bd close` succeeded (check exit code / output)
 2. If you learned something useful → append to `docs/lessons-learned.md`
 3. If you hit a time-wasting problem → add guardrail to `docs/guardrails.md`
 4. If you discovered new work → `bd create "..." task|bug|feature <priority>`, and link it if related: `bd dep relate <new-id> <original-id>`
 5. Commit all changes: `git add -A && git commit -m "[BD-XXX] Brief description"`
+6. Verify the bead is closed: `bd list --status closed --json | grep <id>`
 
 ## STEP 8: STOP
 

--- a/prompts/loop-mcp.md
+++ b/prompts/loop-mcp.md
@@ -163,7 +163,7 @@ If you are running low on context:
 3. If you hit a time-wasting problem → add guardrail to `docs/guardrails.md`
 4. If you discovered new work → `bd create "..." task|bug|feature <priority>`, and link it if related: `bd dep relate <new-id> <original-id>`
 5. Commit all changes: `git add -A && git commit -m "[BD-XXX] Brief description"`
-6. Verify the bead is closed: `bd list --status closed --json | grep -E '"id":\s*"<id>"'`
+6. Verify the bead is closed: `bd list --status closed --json | jq -e --arg id <id> 'any(.[] | .id == $id)'`
 
 ## STEP 8: STOP
 

--- a/prompts/loop-mcp.md
+++ b/prompts/loop-mcp.md
@@ -163,7 +163,7 @@ If you are running low on context:
 3. If you hit a time-wasting problem → add guardrail to `docs/guardrails.md`
 4. If you discovered new work → `bd create "..." task|bug|feature <priority>`, and link it if related: `bd dep relate <new-id> <original-id>`
 5. Commit all changes: `git add -A && git commit -m "[BD-XXX] Brief description"`
-6. Verify the bead is closed: `bd list --status closed --json | grep <id>`
+6. Verify the bead is closed: `bd list --status closed --json | grep -E '"id":\s*"<id>"'`
 
 ## STEP 8: STOP
 

--- a/scripts/ralph-afk.sh
+++ b/scripts/ralph-afk.sh
@@ -175,6 +175,7 @@ echo "" | tee -a "$LOG_FILE"
 declare -a FAIL_HISTORY=()
 CONSECUTIVE_EMPTY=0
 MAX_CONSECUTIVE_EMPTY=3
+PREV_UNCOMMITTED=""
 
 # --- Docker Args ---
 
@@ -322,6 +323,14 @@ for ((i=1; i<=MAX_ITERATIONS; i++)); do
             exit 1
         fi
     fi
+
+    # Detect stale uncommitted files (same files left uncommitted across iterations)
+    CURR_UNCOMMITTED=$(git diff --name-only HEAD 2>/dev/null | sort || true)
+    if [ -n "$CURR_UNCOMMITTED" ] && [ "$CURR_UNCOMMITTED" = "$PREV_UNCOMMITTED" ]; then
+        echo "WARNING: Same uncommitted files as previous iteration — possible stuck pattern" | tee -a "$LOG_FILE"
+        echo "Stale files: $CURR_UNCOMMITTED" | tee -a "$LOG_FILE"
+    fi
+    PREV_UNCOMMITTED="$CURR_UNCOMMITTED"
 
     # Show what changed this iteration
     CHANGED=$(git diff --stat HEAD 2>/dev/null || true)

--- a/scripts/ralph-afk.sh
+++ b/scripts/ralph-afk.sh
@@ -328,7 +328,7 @@ for ((i=1; i<=MAX_ITERATIONS; i++)); do
     CURR_UNCOMMITTED=$(git diff --name-only HEAD 2>/dev/null | sort)
     if [ -n "$CURR_UNCOMMITTED" ] && [ "$CURR_UNCOMMITTED" = "$PREV_UNCOMMITTED" ]; then
         echo "WARNING: Same uncommitted files as previous iteration — possible stuck pattern" | tee -a "$LOG_FILE"
-        echo "Stale files: $CURR_UNCOMMITTED" | tee -a "$LOG_FILE"
+        printf "Stale files:\n%s\n" "$CURR_UNCOMMITTED" | tee -a "$LOG_FILE"
     fi
     PREV_UNCOMMITTED="$CURR_UNCOMMITTED"
 

--- a/scripts/ralph-afk.sh
+++ b/scripts/ralph-afk.sh
@@ -325,7 +325,7 @@ for ((i=1; i<=MAX_ITERATIONS; i++)); do
     fi
 
     # Detect stale uncommitted files (same files left uncommitted across iterations)
-    CURR_UNCOMMITTED=$(git diff --name-only HEAD 2>/dev/null | sort || true)
+    CURR_UNCOMMITTED=$(git diff --name-only HEAD 2>/dev/null | sort)
     if [ -n "$CURR_UNCOMMITTED" ] && [ "$CURR_UNCOMMITTED" = "$PREV_UNCOMMITTED" ]; then
         echo "WARNING: Same uncommitted files as previous iteration — possible stuck pattern" | tee -a "$LOG_FILE"
         echo "Stale files: $CURR_UNCOMMITTED" | tee -a "$LOG_FILE"

--- a/templates/prompt.md
+++ b/templates/prompt.md
@@ -102,7 +102,7 @@ If you are running low on context:
 3. If you hit a time-wasting problem → add guardrail to `docs/guardrails.md`
 4. If you discovered new work → `bd create "..." task|bug|feature <priority>`, and link it if related: `bd dep relate <new-id> <original-id>`
 5. Commit all changes: `git add -A && git commit -m "[BD-XXX] Brief description"`
-6. Verify the bead is closed: `bd list --status closed --json | grep -E '"id":\s*"<id>"'`
+6. Verify the bead is closed: `bd list --status closed --json | jq -e --arg id <id> 'any(.[] | .id == $id)'`
 
 ## STEP 7: STOP
 

--- a/templates/prompt.md
+++ b/templates/prompt.md
@@ -93,11 +93,16 @@ If you are running low on context:
 
 ## STEP 6: COMPLETE THE TASK
 
-1. Close the bead: `bd close <id> --reason "what was done"`
+**CRITICAL — `bd close` is MANDATORY. Do NOT skip it.** Without `bd close`, the bead stays open and will be re-assigned in the next iteration, wasting work.
+
+1. Close the bead FIRST: `bd close <id> --reason "criterion-by-criterion close reason"`
+   - The close reason MUST reference each acceptance criterion and how it was satisfied
+   - Verify `bd close` succeeded (check exit code / output)
 2. If you learned something useful → append to `docs/lessons-learned.md`
 3. If you hit a time-wasting problem → add guardrail to `docs/guardrails.md`
 4. If you discovered new work → `bd create "..." task|bug|feature <priority>`, and link it if related: `bd dep relate <new-id> <original-id>`
 5. Commit all changes: `git add -A && git commit -m "[BD-XXX] Brief description"`
+6. Verify the bead is closed: `bd list --status closed --json | grep <id>`
 
 ## STEP 7: STOP
 

--- a/templates/prompt.md
+++ b/templates/prompt.md
@@ -102,7 +102,7 @@ If you are running low on context:
 3. If you hit a time-wasting problem → add guardrail to `docs/guardrails.md`
 4. If you discovered new work → `bd create "..." task|bug|feature <priority>`, and link it if related: `bd dep relate <new-id> <original-id>`
 5. Commit all changes: `git add -A && git commit -m "[BD-XXX] Brief description"`
-6. Verify the bead is closed: `bd list --status closed --json | grep <id>`
+6. Verify the bead is closed: `bd list --status closed --json | grep -E '"id":\s*"<id>"'`
 
 ## STEP 7: STOP
 

--- a/templates/verify-python.sh
+++ b/templates/verify-python.sh
@@ -36,7 +36,7 @@ echo "✓ Type check passed"
 echo ""
 
 echo "=== TESTS + COVERAGE (pytest) ==="
-${PYTHON_PREFIX}pytest --tb=short -q --cov=src --cov-fail-under=80 --cov-report=term-missing
+${PYTHON_PREFIX}pytest --tb=short -q --timeout=60 --cov=src --cov-fail-under=80 --cov-report=term-missing
 echo "✓ Tests passed, coverage >= 80%"
 echo ""
 


### PR DESCRIPTION
## Summary

- **#46**: Add per-test timeout (60s) to `verify-python.sh` template to prevent individual tests from hanging the entire Docker container. Add stale uncommitted file detection in `ralph-afk.sh` — warns when the same files stay uncommitted across iterations.
- **#43**: Strengthen `bd close` instructions to be MANDATORY with criterion-by-criterion reasons. Add `bd update` claim step and post-close verification to prompt templates.

## Test plan

- [ ] `bash -n` syntax check passes on ralph-afk.sh
- [ ] Verify pytest --timeout=60 flag is present in verify template
- [ ] Review prompt wording changes for clarity

Closes #43, closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)